### PR TITLE
License violation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "dataworkstr/excel",
+  "name": "maatwebsite/excel",
   "description": "An eloquent way of importing and exporting Excel and CSV in Laravel 5 with the power of PHPExcel",
   "license": "LGPL",
   "keywords": [
@@ -18,6 +18,7 @@
     },
 
   "authors": [
+        // re-add original copyright owner
         {
             "name": "Oner Ciller",
             "email": "admin@yellow.com.tr",


### PR DESCRIPTION
Please read our license: https://github.com/Maatwebsite/Laravel-Excel#license You are currently violating the license by removing the original copyright owner.

Having an own copy of the package is no problem (as long as you keep the original copyright owner on there), but it's not necessary to re-distribute to packagist. You can easily pull in a copy of the package, without having to duplicate the package on packagist:

```
"repositories": [
    { "type": "vcs", "url": "https://github.com/dataworkstr/Laravel-Excel" },
  ],
  "require": {"maatwebsite/excel": "your-branch/tag"}
```